### PR TITLE
Allow host header to be overridden

### DIFF
--- a/core/scenario/requester/http.go
+++ b/core/scenario/requester/http.go
@@ -217,7 +217,11 @@ func (h *HttpRequester) initRequestInstance() (err error) {
 	// Headers
 	header := make(http.Header)
 	for k, v := range h.packet.Headers {
-		header.Set(k, v)
+		if strings.EqualFold(k, "Host") {
+			h.request.Host = v
+		} else {
+			header.Set(k, v)
+		}
 	}
 
 	ua := header.Get("User-Agent")

--- a/core/scenario/requester/http_test.go
+++ b/core/scenario/requester/http_test.go
@@ -253,7 +253,7 @@ func TestInitRequest(t *testing.T) {
 		ID:       1,
 		Protocol: types.ProtocolHTTPS,
 		Method:   http.MethodGet,
-		URL:      "https://test.com",
+		URL:      "https://test.localhost",
 		Payload:  "payloadtest",
 		Auth: types.Auth{
 			Username: "test",
@@ -263,6 +263,7 @@ func TestInitRequest(t *testing.T) {
 			"Header1":    "Value1",
 			"Header2":    "Value2",
 			"User-Agent": "Firefox",
+			"Host":       "test.com",
 		},
 	}
 	expectedWithHeaders, _ := http.NewRequest(sWithHeaders.Method,
@@ -272,6 +273,7 @@ func TestInitRequest(t *testing.T) {
 	expectedWithHeaders.Header.Set("Header1", "Value1")
 	expectedWithHeaders.Header.Set("Header2", "Value2")
 	expectedWithHeaders.Header.Set("User-Agent", "Firefox "+types.DdosifyUserAgent)
+	expectedWithHeaders.Host = "test.com"
 	expectedWithHeaders.SetBasicAuth(sWithHeaders.Auth.Username, sWithHeaders.Auth.Password)
 
 	// Request keep-alive condition
@@ -332,6 +334,9 @@ func TestInitRequest(t *testing.T) {
 
 				if !reflect.DeepEqual(h.request.URL, test.request.URL) {
 					t.Errorf("URL Expected: %#v, Found: \n%#v", test.request.URL, h.request.URL)
+				}
+				if !reflect.DeepEqual(h.request.Host, test.request.Host) {
+					t.Errorf("Host Expected: %#v, Found: \n%#v", test.request.Host, h.request.Host)
 				}
 				if !reflect.DeepEqual(h.request.Body, test.request.Body) {
 					t.Errorf("Body Expected: %#v, Found: \n%#v", test.request.Body, h.request.Body)


### PR DESCRIPTION
## Problem

We were trying to benchmark a multi-tenant application locally, so were using localhost subdomains (e.g. `test1.localhost` & `test2.localhost`) to easily test multiple domains without any extra setup.  Chrome & Firefox seem to resolve these to localhost as [RFC-6761 section 6.3](https://datatracker.ietf.org/doc/html/rfc6761#section-6.3) says may be done.  Other applications like `curl` don't treat this specially, but the host header can be overridden (e.g. `curl localhost:8081 -H test.localhost:8081`).  I had hoped the same could be done in ddosify, but the host header seemed to get ignored.

For example, in one terminal I ran `nc -l 8081`, then in another I ran `ddosify -t http://localhost:8081 -h 'Host: test.localhost:8081' -n 1 -d 1` which sent the following request to netcat

```
GET / HTTP/1.1
Host: localhost:8081
User-Agent: DdosifyHammer
Connection: close
Accept-Encoding: gzip

```

I was expecting

```
GET / HTTP/1.1
Host: test.localhost:8081
User-Agent: DdosifyHammer
Connection: close
Accept-Encoding: gzip

```

## Solution

[net/http.Request](https://pkg.go.dev/net/http#Request) has a Host field that must be set in order to override the Host header, so I checked for the Host header key to set this field instead of adding the Host header to the http.Header map where it would get ignored.