### PR TITLE
Proxy latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ ddosify [FLAG]
 | `-n`   | Total request count                                      | `int`    | `100`   | No         |
 | `-d`   | Test duration in seconds.                                | `int`    | `10`    | No         |
 | `-p`   | Protocol of the request. Supported protocols are *HTTP, HTTPS*. HTTP/2 support is only available by using a config file as described. More protocols will be added.                                | `string`    | `HTTPS`    | No         |
-| `-m`   | Request method. Available methods for HTTP(s) are *GET, POST, PUT, DELETE, UPDATE, PATCH* | `string`    | `GET`    | No  |
+| `-m`   | Request method. Available methods for HTTP(s) are *GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS* | `string`    | `GET`    | No  |
 | `-b`   | The payload of the network packet. AKA body for the HTTP.  | `string`    | -    | No         |
 | `-a`   | Basic authentication. Usage: `-a username:password`        | `string`    | -    | No         |
 | `-h`   | Headers of the request. You can provide multiple headers with multiple `-h` flag.  | `string`| -    | No         |

--- a/core/engine.go
+++ b/core/engine.go
@@ -172,6 +172,7 @@ func (e *engine) runWorker(scenarioStartTime time.Time) {
 	res.Others = make(map[string]interface{})
 	res.Others["hammerOthers"] = e.hammer.Others
 	res.Others["proxyCountry"] = e.proxyService.GetProxyCountry(p)
+	res.Others["proxyLatency"] = e.proxyService.GetLatency(p)
 	e.responseChan <- res
 }
 

--- a/core/proxy/base.go
+++ b/core/proxy/base.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"time"
 )
 
 var AvailableProxyServices = make(map[string]ProxyService)
@@ -48,6 +49,7 @@ type ProxyService interface {
 	GetProxy() *url.URL
 	ReportProxy(addr *url.URL, reason string) *url.URL
 	GetProxyCountry(*url.URL) string
+	GetLatency(*url.URL) time.Duration
 	Done() error
 }
 

--- a/core/proxy/single.go
+++ b/core/proxy/single.go
@@ -22,6 +22,7 @@ package proxy
 
 import (
 	"net/url"
+	"time"
 )
 
 const ProxyTypeSingle = "single"
@@ -55,6 +56,11 @@ func (sp *singleProxyStrategy) ReportProxy(addr *url.URL, reason string) *url.UR
 
 func (sp *singleProxyStrategy) GetProxyCountry(addr *url.URL) string {
 	return "unknown"
+}
+
+func (sp *singleProxyStrategy) GetLatency(addr *url.URL) time.Duration {
+	// We may want to calculate latency for single proxy strategy also.
+	return time.Duration(0)
 }
 
 func (sp *singleProxyStrategy) Done() error {

--- a/core/scenario/requester/http.go
+++ b/core/scenario/requester/http.go
@@ -121,7 +121,7 @@ func (h *HttpRequester) Send() (res *types.ResponseItem) {
 		StatusCode:       statusCode,
 		RequestTime:      reqStartTime,
 		Duration:         durations.totalDuration(),
-		ContentLenth:     contentLength,
+		ContentLength:    contentLength,
 		Err:              requestErr,
 		Custom: map[string]interface{}{
 			"dnsDuration":           durations.getDNSDur(),

--- a/core/scenario/service.go
+++ b/core/scenario/service.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"go.ddosify.com/ddosify/core/scenario/requester"
 	"go.ddosify.com/ddosify/core/types"
 )
@@ -68,6 +69,7 @@ func (s *ScenarioService) Init(ctx context.Context, scenario types.Scenario, pro
 // Returns error only if types.Response.Err.Type is types.ErrorProxy or types.ErrorIntented
 func (s *ScenarioService) Do(proxy *url.URL, startTime time.Time) (response *types.Response, err *types.RequestError) {
 	response = &types.Response{ResponseItems: []*types.ResponseItem{}}
+	response.ResponseID = uuid.New()
 	response.StartTime = startTime
 	response.ProxyAddr = proxy
 

--- a/core/scenario/service.go
+++ b/core/scenario/service.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"go.ddosify.com/ddosify/core/scenario/requester"
 	"go.ddosify.com/ddosify/core/types"
 )
@@ -69,7 +68,6 @@ func (s *ScenarioService) Init(ctx context.Context, scenario types.Scenario, pro
 // Returns error only if types.Response.Err.Type is types.ErrorProxy or types.ErrorIntented
 func (s *ScenarioService) Do(proxy *url.URL, startTime time.Time) (response *types.Response, err *types.RequestError) {
 	response = &types.Response{ResponseItems: []*types.ResponseItem{}}
-	response.ResponseID = uuid.New()
 	response.StartTime = startTime
 	response.ProxyAddr = proxy
 

--- a/core/types/response.go
+++ b/core/types/response.go
@@ -29,9 +29,6 @@ import (
 
 // Response is corresponding to Scenario. Each Scenario has a Response after the request is done.
 type Response struct {
-	// Each response object has a unique identifier
-	ResponseID uuid.UUID
-
 	// First request start time for the Scenario
 	StartTime time.Time
 

--- a/core/types/response.go
+++ b/core/types/response.go
@@ -29,6 +29,9 @@ import (
 
 // Response is corresponding to Scenario. Each Scenario has a Response after the request is done.
 type Response struct {
+	// Each response object has a unique identifier
+	ResponseID uuid.UUID
+
 	// First request start time for the Scenario
 	StartTime time.Time
 
@@ -60,7 +63,7 @@ type ResponseItem struct {
 	Duration time.Duration
 
 	// Response content length
-	ContentLenth int64
+	ContentLength int64
 
 	// Error occurred at request time.
 	Err RequestError

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ var (
 	duration = flag.Int("d", types.DefaultDuration, "Test duration in seconds")
 	loadType = flag.String("l", types.DefaultLoadType, "Type of the load test [linear, incremental, waved]")
 
-	protocol = flag.String("p", types.DefaultProtocol, "[HTTP, HTTPS]")
+	protocol = flag.String("p", types.DefaultProtocol, "Protocol [HTTP, HTTPS]")
 	method   = flag.String("m", types.DefaultMethod,
 		"Request Method Type. For Http(s):[GET, POST, PUT, DELETE, UPDATE, PATCH]")
 	payload = flag.String("b", "", "Payload of the network packet")


### PR DESCRIPTION
- proxyLatency method added to ProxyService 
- Some minor bug fixes & typo fixes

@fatihbaltaci I think we should reconsider the RequestID UUID field. Since 1 UUID is equal to 36 bytes., we'll store an extra 36 bytes for each request. That means 3.4 MB for a 100k load test.