### PR TITLE
Add zsh shell auto-completion function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ## Installation
 
-`ddosify` is available via [Docker](https://hub.docker.com/r/ddosify/ddosify), [Docker Extension](https://hub.docker.com/extensions/ddosify/ddosify-docker-extension), [Homebrew Tap](#homebrew-tap-macos-and-linux), and downloadable pre-compiled binaries from the [releases page](https://github.com/ddosify/ddosify/releases/latest) for macOS, Linux and Windows.
+`ddosify` is available via [Docker](https://hub.docker.com/r/ddosify/ddosify), [Docker Extension](https://hub.docker.com/extensions/ddosify/ddosify-docker-extension), [Homebrew Tap](#homebrew-tap-macos-and-linux), and downloadable pre-compiled binaries from the [releases page](https://github.com/ddosify/ddosify/releases/latest) for macOS, Linux and Windows. For auto-completion, see: [Ddosify Completions](https://github.com/ddosify/ddosify/blob/master/completions/README.md).
 
 ### Docker
 

--- a/completions/README.md
+++ b/completions/README.md
@@ -18,10 +18,8 @@
   # ~/.zshrc
 
   plugins=(
-    git
-    zsh-autosuggestions
-    ddosify
     ...
+    ddosify
   )
   ```
 

--- a/completions/README.md
+++ b/completions/README.md
@@ -1,0 +1,37 @@
+# Shell Completion
+
+## ZHS
+
+`completions/_ddosify` provides a basic auto-completions. You can apply one of the steps to get an auto-completion successfully.
+
+- You can locate the file in any directory referenced by `$fpath`.
+
+  - It can be checked out through;
+
+  ```SHELL
+  echo $fpath | tr ' ' '\n'
+  ```
+
+  - For example, if you are using `oh-my-zsh` you can add it as a plugin after locating file under plugin related directory appeared in `$fpath`.
+
+  ```
+  # ~/.zshrc
+
+  plugins=(
+    git
+    zsh-autosuggestions
+    ddosify
+    ...
+  )
+  ```
+
+- If you don't have an appropriate directory,
+  - It can be generated through;
+  ```
+  mkdir -p ${ZDOTDIR:-~}/.zsh_functions
+  echo 'fpath+=${ZDOTDIR:-~}/.zsh_functions' >> ${ZDOTDIR:-~}/.zshrc
+  ```
+  - Then, the file should be copied to this directory;
+  ```
+  cp completions/_ddosify ${ZDOTDIR:-~}/.zsh_functions/_ddosify
+  ```

--- a/completions/README.md
+++ b/completions/README.md
@@ -2,34 +2,41 @@
 
 ## Zsh
 
-`completions/_ddosify` provides a basic auto-completions. You can apply one of the steps to get an auto-completion successfully.
+`completions/_ddosify` provides a basic auto-completions. You can apply one of the steps to get an auto-completion successfully. 
 
-- You can locate the file in any directory referenced by `$fpath`.
+You can locate the file in any directory referenced by `$fpath`. You can use the following command to list directories in `$fpath`.
 
-  - It can be checked out through;
+```bash
+echo $fpath | tr ' ' '\n'
+```
 
-  ```SHELL
-  echo $fpath | tr ' ' '\n'
-  ```
+For example, if you are using [oh-my-zsh](https://ohmyz.sh/) you can add it as a plugin after locating file under plugin related directory appeared in `$fpath`. You can create a directory named `ddosify` under `~/.oh-my-zsh/plugins` and copy `_ddosify` file to it.
 
-  - For example, if you are using `oh-my-zsh` you can add it as a plugin after locating file under plugin related directory appeared in `$fpath`.
+```bash
+mkdir -p ~/.oh-my-zsh/plugins/ddosify
+cp completions/_ddosify ~/.oh-my-zsh/plugins/ddosify
+```
 
-  ```
-  # ~/.zshrc
+Then, you can add `ddosify` to your plugins list in `~/.zshrc` file.
 
-  plugins=(
-    ...
-    ddosify
-  )
-  ```
+```
+# ~/.zshrc
 
-- If you don't have an appropriate directory,
-  - It can be generated through;
-  ```
-  mkdir -p ${ZDOTDIR:-~}/.zsh_functions
-  echo 'fpath+=${ZDOTDIR:-~}/.zsh_functions' >> ${ZDOTDIR:-~}/.zshrc
-  ```
-  - Then, the file should be copied to this directory;
-  ```
-  cp completions/_ddosify ${ZDOTDIR:-~}/.zsh_functions/_ddosify
-  ```
+plugins=(
+  ...
+  ddosify
+)
+```
+
+If you don't have an appropriate directory, you can create one and add it to `$fpath`.
+  
+```
+mkdir -p ${ZDOTDIR:-~}/.zsh_functions
+echo 'fpath+=${ZDOTDIR:-~}/.zsh_functions' >> ${ZDOTDIR:-~}/.zshrc
+```
+
+Then, you can copy `_ddosify` file to the directory you created.
+
+```
+cp completions/_ddosify ${ZDOTDIR:-~}/.zsh_functions/_ddosify
+```

--- a/completions/README.md
+++ b/completions/README.md
@@ -1,6 +1,6 @@
-# Shell Completion
+# Shell completions
 
-## ZHS
+## Zsh
 
 `completions/_ddosify` provides a basic auto-completions. You can apply one of the steps to get an auto-completion successfully.
 

--- a/completions/_ddosify
+++ b/completions/_ddosify
@@ -1,0 +1,32 @@
+#compdef ddosify _ddosify
+
+typeset -A opt_args
+
+_ddosify() {
+    local curcontext="$curcontext" state line
+    local -a opts
+
+    opts+=(
+        "-t[Target URL.]"
+        "-P[Proxy address as protocol\://username\:password@host\:port. Supported proxies \[http(s), socks\].]"
+        "-T[Request timeout in seconds (default 5).]" 
+        "-a[Basic authentication, username\:password.]"
+        "-b[Payload of the network packet (body).]"
+        "-cert_key_path[A path to a certificate key file (usually called 'key.pem').]:filename:_files"
+        "-cert_path[A path to a certificate file (usually called 'cert.pem'.)]:filename:_files"
+        "-config[Json config file path. If a config file is provided, other flag values will be ignored.]:filename:_files"
+        "-d[Test duration in seconds (default 10).]"
+        "-debug[Iterates the scenario once and prints curl-like verbose result.]"
+        "-h[Request Headers. Ex\: -h 'Accept\: text/html' -h 'Content-Type\: application/xml'.]"
+        "-l[Type of the load test \['linear', 'incremental', 'waved'\] (default 'linear').]"
+        "-m[Request Method Type. For Http(s)\:\['GET', 'POST', 'PUT', 'DELETE', 'UPDATE', 'PATCH'\] (default 'GET').]"
+        "-n[Total iteration count (default 100).]"
+        "-o[Output destination (default 'stdout').]"
+        "-version[Prints version, git commit, built date (utc), go information and quit.]"
+    )
+
+    _arguments -s -w : $opts && return 0
+
+    return 1
+}
+


### PR DESCRIPTION
This PR introduces a basic auto-completion function for zsh shell.
- Options/flags were extracted based on help page.
- The guide includes different ways of setup options.
- I believe, completions setup can be directly embedded to actual installation of the CLI [here](https://github.com/ddosify/ddosify/blob/master/scripts/install.sh).

<img width="1299" alt="Screen Shot 2023-02-05 at 03 54 58" src="https://user-images.githubusercontent.com/43863606/216796003-96e552a9-823f-4e26-aec3-9455ebef7b2d.png">