### PR TITLE
fix camelCase on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,11 +543,11 @@ ddosify -config ddosify_config_dynamic.json
 }
 ```
 ## Correlation
-Ddosify enables you to capture variables from steps using **jsonPath**, **xpath**, or **regular expressions**. Later, in the subsequent steps, you can inject both the captured variables and the scenario-scoped global variables.
+Ddosify enables you to capture variables from steps using **json_path**, **xpath**, or **regular expressions**. Later, in the subsequent steps, you can inject both the captured variables and the scenario-scoped global variables.
 
 > **:warning: Points to keep in mind**
 > - You must specify **'header_key'** when capturing from header.
-> - For jsonPath syntax, please take a look at [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) doc.
+> - For json_path syntax, please take a look at [gjson syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) doc.
 > - Regular expression are expected in  **'Golang'** style regex. For converting your existing regular expressions, you can use [regex101](https://regex101.com/).
 
 You can use **debug** parameter to validate your config.
@@ -556,17 +556,17 @@ You can use **debug** parameter to validate your config.
 ddosify -config ddosify_config_correlation.json -debug
 ```
 
-### Capture With JsonPath
+### Capture With json_path
 ```json
 {
     "steps": [
         {
             "capture_env": {
-                "NUM" :{"from":"body","jsonPath":"num"},
-                "NAME" :{"from":"body","jsonPath":"name"},
-                "SQUAD" :{"from":"body","jsonPath":"squad"},
-                "PLAYERS" :{"from":"body","jsonPath":"squad.players"},
-                "MESSI" : {"from":"body","jsonPath":"squad.players.0"},             
+                "NUM" :{"from":"body","json_path":"num"},
+                "NAME" :{"from":"body","json_path":"name"},
+                "SQUAD" :{"from":"body","json_path":"squad"},
+                "PLAYERS" :{"from":"body","json_path":"squad.players"},
+                "MESSI" : {"from":"body","json_path":"squad.players.0"},             
             }         
         }
     ]
@@ -646,11 +646,11 @@ On array-like captured variables or environment vars, the **rand( )** function c
             },
             "payload" : "{{COMPANY_NAME}}",
             "capture_env": {
-                "NUM" :{"from":"body","jsonPath":"num"},
-                "NAME" :{"from":"body","jsonPath":"name"},
-                "SQUAD" :{"from":"body","jsonPath":"squad"},
-                "PLAYERS" :{"from":"body","jsonPath":"squad.players"},
-                "MESSI" : {"from":"body","jsonPath":"squad.players.0"},
+                "NUM" :{"from":"body","json_path":"num"},
+                "NAME" :{"from":"body","json_path":"name"},
+                "SQUAD" :{"from":"body","json_path":"squad"},
+                "PLAYERS" :{"from":"body","json_path":"squad.players"},
+                "MESSI" : {"from":"body","json_path":"squad.players.0"},
                 "TOKEN" :{"from":"header", "header_key":"Authorization"},
                 "CONTENT_TYPE" :{"from":"header", "header_key":"Content-Type" ,"regexp":{"exp":"application\/(\\w)+","matchNo":0}}             
             }         

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ There is an example config file at [config_examples/config.json](/config_example
                 "id": 1,
                 "url": "http://target.com/endpoint1",
                 "capture_env": {
-                     "NUM" :{"from":"body","jsonPath":"num"},
+                     "NUM" :{"from":"body","json_path":"num"},
                 }
             },
         ]

--- a/core/scenario/scripting/extraction/json.go
+++ b/core/scenario/scripting/extraction/json.go
@@ -69,7 +69,7 @@ func (je jsonExtractor) extractFromString(source string, jsonPath string) (inter
 
 	// path not found
 	if result.Raw == "" && result.Type == gjson.Null {
-		return "", fmt.Errorf("no match for this jsonPath")
+		return "", fmt.Errorf("no match for the json path: %s", jsonPath)
 	}
 
 	switch result.Type {
@@ -99,7 +99,7 @@ func (je jsonExtractor) extractFromByteSlice(source []byte, jsonPath string) (in
 
 	// path not found
 	if result.Raw == "" && result.Type == gjson.Null {
-		return "", fmt.Errorf("no match for this jsonPath")
+		return "", fmt.Errorf("no match for the json path: %s", jsonPath)
 	}
 
 	switch result.Type {

--- a/core/scenario/scripting/extraction/json_test.go
+++ b/core/scenario/scripting/extraction/json_test.go
@@ -270,7 +270,7 @@ func TestJsonExtract_JsonPathNotFound(t *testing.T) {
 	je := jsonExtractor{}
 	val, err := je.extractFromByteSlice(byteSlice, "age2")
 
-	expected := "no match for this jsonPath"
+	expected := "no match for the json path: age2"
 	if !strings.EqualFold(err.Error(), expected) {
 		t.Errorf("TestJsonExtract_JsonPathNotFound failed, expected %#v, found %#v", expected, err)
 	}

--- a/core/scenario/scripting/extraction/regex.go
+++ b/core/scenario/scripting/extraction/regex.go
@@ -17,7 +17,7 @@ func (ri *regexExtractor) extractFromString(text string, matchNo int) (string, e
 	matches := ri.r.FindAllString(text, -1)
 
 	if matches == nil {
-		return "", fmt.Errorf("no match for this regex")
+		return "", fmt.Errorf("no match for the Regex: %s  Match no: %d", ri.r.String(), matchNo)
 	}
 
 	if len(matches) > matchNo {
@@ -30,7 +30,7 @@ func (ri *regexExtractor) extractFromByteSlice(text []byte, matchNo int) ([]byte
 	matches := ri.r.FindAll(text, -1)
 
 	if matches == nil {
-		return nil, fmt.Errorf("no match for this regex")
+		return nil, fmt.Errorf("no match for the Regex: %s  Match no: %d", ri.r.String(), matchNo)
 	}
 
 	if len(matches) > matchNo {

--- a/core/scenario/scripting/extraction/xml.go
+++ b/core/scenario/scripting/extraction/xml.go
@@ -20,7 +20,7 @@ func (xe xmlExtractor) extractFromByteSlice(source []byte, xPath string) (interf
 	// returns the first matched element
 	foundNode, err := xmlquery.Query(rootNode, xPath)
 	if foundNode == nil || err != nil {
-		return nil, fmt.Errorf("no match for this xpath")
+		return nil, fmt.Errorf("no match for the xPath: %s", xPath)
 	}
 
 	return foundNode.InnerText(), nil


### PR DESCRIPTION
- `jsonPath` to `json_path` fix on the readme
- capture expression added on uncaptured error message