### PR TITLE
fix: stabilize go test suite

### DIFF
--- a/ddosify_engine/config/json_test.go
+++ b/ddosify_engine/config/json_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"reflect"
@@ -343,11 +344,49 @@ func TestCreateHammerPayload(t *testing.T) {
 
 func TestCreateHammerMultipartPayload(t *testing.T) {
 	t.Parallel()
-	jsonReader, _ := NewConfigReader(readConfigFile("config_testdata/config_multipart_payload.json"), ConfigTypeJson)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<svg></svg>"))
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	conf := fmt.Sprintf(`{
+	    "steps": [
+	        {
+	            "id": 1,
+	            "url": "https://app.servdown.com/accounts/login/?next=/",
+	            "method": "GET",
+	            "payload_multipart": [
+	                {
+	                    "name": "example-name-1",
+	                    "value": "config_testdata/test_img.svg",
+	                    "type": "file"
+	                },
+	                {
+	                    "name": "example-name-2",
+	                    "value": "%s",
+	                    "type": "file",
+	                    "src": "remote"
+	                },
+	                {
+	                    "name": "example-name-3",
+	                    "value": "text-field-value"
+	                },
+	                {
+	                    "name": "example-name-4",
+	                    "value": "123123",
+	                    "type": "text"
+	                }
+	            ]
+	        }
+	    ]
+	}`, server.URL)
+
+	jsonReader, _ := NewConfigReader([]byte(conf), ConfigTypeJson)
 
 	h, err := jsonReader.CreateHammer()
 	if err != nil {
-		t.Errorf("TestCreateHammerMultipartPayload error occurred: %v", err)
+		t.Fatalf("TestCreateHammerMultipartPayload error occurred: %v", err)
 	}
 	steps := h.Scenario.Steps
 

--- a/ddosify_engine/core/scenario/client_pool_cookie_test.go
+++ b/ddosify_engine/core/scenario/client_pool_cookie_test.go
@@ -166,50 +166,21 @@ func TestSetCookiesSecure(t *testing.T) {
 
 	secureCookieName := "https-cookie"
 	secureCookieVal := "secure-cookie"
-
-	var httpServerGotCookie *http.Cookie
-	reqHandler := func(w http.ResponseWriter, r *http.Request) {
-		httpServerGotCookie, _ = r.Cookie(secureCookieName)
-	}
-
-	var httpsServerGotCookie *http.Cookie
-	secureReqHandler := func(w http.ResponseWriter, r *http.Request) {
-		httpsServerGotCookie, _ = r.Cookie(secureCookieName)
-	}
-
-	path := "/default"
-	mux := http.NewServeMux()
-	mux.HandleFunc(path, reqHandler)
-
-	host := httptest.NewServer(mux)
-	defer host.Close()
-
-	pathSecure := "/secure"
-	muxHttps := http.NewServeMux()
-	muxHttps.HandleFunc(pathSecure, secureReqHandler)
-
-	secureHost := httptest.NewTLSServer(muxHttps)
-	defer secureHost.Close()
-
-	c := secureHost.Client()
-	c.Jar, _ = cookiejar.New(nil)
+	secureURL, _ := url.Parse("https://example.com")
+	insecureURL, _ := url.Parse("http://example.com")
+	jar, _ := cookiejar.New(nil)
 
 	secureCookie := http.Cookie{Name: secureCookieName, Value: secureCookieVal, Secure: true}
-	// set cookies
-	url, _ := url.Parse(secureHost.URL)
-	c.Jar.SetCookies(url, []*http.Cookie{&secureCookie})
-
-	c.Get(host.URL + path)
-	c.Get(secureHost.URL + pathSecure)
+	jar.SetCookies(secureURL, []*http.Cookie{&secureCookie})
 
 	// expect secure cookie to be sent only to secure host
-
-	if httpServerGotCookie != nil {
-		t.Errorf("TestSetCookiesSecure, expected no cookie to be sent to http host, got %s", httpServerGotCookie.Value)
+	if cookies := jar.Cookies(insecureURL); len(cookies) > 0 {
+		t.Errorf("TestSetCookiesSecure, expected no cookie to be sent to http host, got %s", cookies[0].Value)
 	}
 
-	if httpsServerGotCookie == nil || httpsServerGotCookie.Value != secureCookieVal {
-		t.Errorf("TestSetCookiesSecure, expected cookie to be sent to https host, got %s", httpsServerGotCookie.Value)
+	cookies := jar.Cookies(secureURL)
+	if len(cookies) == 0 || cookies[0].Value != secureCookieVal {
+		t.Errorf("TestSetCookiesSecure, expected cookie to be sent to https host, got %v", cookies)
 	}
 }
 

--- a/ddosify_engine/core/scenario/data/csv_test.go
+++ b/ddosify_engine/core/scenario/data/csv_test.go
@@ -34,8 +34,12 @@ func TestValidateCsvConf(t *testing.T) {
 
 func TestReadCsv_RemoteErr(t *testing.T) {
 	t.Parallel()
+	server := httptest.NewServer(http.NotFoundHandler())
+	path := server.URL + "/csv"
+	server.Close()
+
 	conf := types.CsvConf{
-		Path:          "https://invalidurl.com/csv",
+		Path:          path,
 		Delimiter:     ";",
 		SkipFirstLine: true,
 		Vars: map[string]types.Tag{

--- a/ddosify_engine/core/scenario/service_test.go
+++ b/ddosify_engine/core/scenario/service_test.go
@@ -602,7 +602,7 @@ func TestCreateRequestersErrorOnRequesterInit(t *testing.T) {
 	}
 }
 
-func TestnewSleeper(t *testing.T) {
+func TestNewSleeper(t *testing.T) {
 	t.Parallel()
 
 	sleepRange := "300-500"


### PR DESCRIPTION
Fixes #338

Small test-suite cleanup. `go test ./...` was blocked by the bad `TestnewSleeper` name on newer Go, and after that a couple tests still leaned on outside HTTP behavior. Kinda flaky, low-key annoying.

Repro before this:

```sh
cd ddosify_engine
go test ./...
```

What changed:
- rename `TestnewSleeper` to `TestNewSleeper`
- use local `httptest` for remote multipart payload
- stop depending on `invalidurl.com` for CSV remote error
- make the secure cookie test avoid localhost behavior changes in newer Go

Checked:

```sh
cd ddosify_engine
go test ./...
```
